### PR TITLE
fix holidays with dashes in name for sedra find

### DIFF
--- a/src/sedra.ts
+++ b/src/sedra.ts
@@ -190,6 +190,16 @@ export class Sedra {
       const p2 = parsha[1];
       const num1 = parsha2id.get(p1);
       const num2 = parsha2id.get(p2);
+      //Attempt to find Holidays with dash such as Sukkot Shabbat Chol ha-Moed
+      if (
+        !num1 &&
+        !num2 &&
+        this.theSedraArray.indexOf(parsha.join('-')) !== -1
+      ) {
+        const rejoinedName = parsha.join('-');
+        const idx = this.theSedraArray.indexOf(rejoinedName);
+        return new HDate(this.firstSaturday + idx * 7);
+      }
       if (
         typeof num1 !== 'number' ||
         typeof num2 !== 'number' ||

--- a/test/sedra.spec.ts
+++ b/test/sedra.spec.ts
@@ -116,6 +116,8 @@ test('find', () => {
   expect(dt(sedra.find('Chukat'))).toBe('2021-06-19');
   expect(sedra.find(['Chukat', 'Balak'])).toBe(null);
   expect(sedra.find('Chukat-Balak')).toBe(null);
+  const sedra5785 = new Sedra(5785, false);
+  expect(dt(sedra5785.find('Sukkot Shabbat Chol ha-Moed'))).toBe('2024-10-19');
 });
 
 test('find-number', () => {


### PR DESCRIPTION
When we use find for a holiday with a dash, it can't 'find' that shabbos since it doesn't do the lookup similar to the way it does for 'Yom Kippur' in the earlier block  where (typeof parsha === 'string')

I also added a test to demonstrate the problem and tested that this fixed it.