### PR TITLE
Migrate Rollup config to TypeScript and simplify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "jest": "^29.7.0",
         "quick-lru": "<=6.1.2",
         "rollup": "^4.24.3",
+        "rollup-plugin-bundle-size": "^1.0.3",
         "rollup-plugin-dts": "^6.1.1",
         "ttag-cli": "^1.10.12",
         "typedoc": "^0.26.10",
@@ -5044,6 +5045,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6134,6 +6142,19 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
+      }
+    },
+    "node_modules/gzip-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "integrity": "sha512-6s8trQiK+OMzSaCSVXX+iqIcLV9tC+E73jrJrJTyS4h/AJhlxHvzFKqM1YLDJWRGgHX8uLkBeXkA0njNj39L4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/hard-rejection": {
@@ -7999,6 +8020,106 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/maxmin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
+      "integrity": "sha512-NWlApBjW9az9qRPaeg7CX4sQBWwytqz32bIEo1PW9pRW+kBP9KLRfJO3UC+TV31EcQZEUq7eMzikC7zt3zPJcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^3.0.0",
+        "pretty-bytes": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/maxmin/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
@@ -8453,6 +8574,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -9004,6 +9145,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+      "integrity": "sha512-eb7ZAeUTgfh294cElcu51w+OTRp/6ItW758LjwJSK72LDevcuJn0P4eD71PLMDGPwwatXmAmYHTkzvpKlJE3ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-format": {
@@ -9655,6 +9809,87 @@
         "@rollup/rollup-win32-ia32-msvc": "4.24.3",
         "@rollup/rollup-win32-x64-msvc": "4.24.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-size/-/rollup-plugin-bundle-size-1.0.3.tgz",
+      "integrity": "sha512-aWj0Pvzq90fqbI5vN1IvUrlf4utOqy+AERYxwWjegH1G8PzheMnrRIgQ5tkwKVtQMDP0bHZEACW/zLDF+XgfXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "maxmin": "^2.1.0"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-size/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/rollup-plugin-dts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "npm run po2json && npm run version && npm run build:rollup --production",
     "prepublish": "npm run build",
     "version": "node ./version.cjs package.json src/pkgVersion.ts",
-    "po2json": "node ./po2json.cjs po/*.po",
+    "po2json": "node ./po2json.cjs po/he.po po/ashkenazi.po",
     "docs": "typedoc",
     "pretest": "npm run build",
     "lint": "gts lint",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dist"
   ],
   "scripts": {
-    "build:rollup": "rollup -c",
+    "build:rollup": "rollup -c --configPlugin typescript",
     "build": "npm run po2json && npm run version && npm run build:rollup --production",
     "prepublish": "npm run build",
     "version": "node ./version.cjs package.json src/pkgVersion.ts",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "jest": "^29.7.0",
     "quick-lru": "<=6.1.2",
     "rollup": "^4.24.3",
+    "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-dts": "^6.1.1",
     "ttag-cli": "^1.10.12",
     "typedoc": "^0.26.10",

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -1,6 +1,7 @@
 const {nodeResolve} = require('@rollup/plugin-node-resolve');
 const commonjs = require('@rollup/plugin-commonjs');
 const babel = require('@rollup/plugin-babel');
+const bundleSize = require('rollup-plugin-bundle-size');
 const json = require('@rollup/plugin-json');
 const terser = require('@rollup/plugin-terser');
 const typescript = require('@rollup/plugin-typescript');
@@ -21,7 +22,11 @@ module.exports = [
   {
     input: 'src/index.ts',
     output: [
-      {file: pkg.main, format: 'cjs', name: pkg.name, banner,
+      {
+        file: pkg.main,
+        format: 'cjs',
+        name: pkg.name,
+        banner,
         sourcemap: true,
         inlineDynamicImports: true,
         globals: {
@@ -35,24 +40,32 @@ module.exports = [
       babel({
         babelHelpers: 'bundled',
         presets: [
-          ['@babel/preset-env', {
-            modules: false,
-            targets: {
-              node: TARGET_NODE_VER,
+          [
+            '@babel/preset-env',
+            {
+              modules: false,
+              targets: {
+                node: TARGET_NODE_VER,
+              },
             },
-          }],
+          ],
         ],
         exclude: ['node_modules/**'],
       }),
       nodeResolve(),
       commonjs(),
+      bundleSize(),
     ],
     // external: ['temporal-polyfill'],
   },
   {
     input: 'src/index.ts',
     output: [
-      {file: pkg.module, format: 'es', name: pkg.name, banner,
+      {
+        file: pkg.module,
+        format: 'es',
+        name: pkg.name,
+        banner,
         sourcemap: true,
         inlineDynamicImports: true,
         globals: {
@@ -61,23 +74,26 @@ module.exports = [
       },
     ],
     plugins: [
-
       typescript(),
       json({compact: true, preferConst: true}),
       babel({
         babelHelpers: 'bundled',
         presets: [
-          ['@babel/preset-env', {
-            modules: false,
-            targets: {
-              node: TARGET_NODE_VER,
+          [
+            '@babel/preset-env',
+            {
+              modules: false,
+              targets: {
+                node: TARGET_NODE_VER,
+              },
             },
-          }],
+          ],
         ],
         exclude: ['node_modules/**'],
       }),
       nodeResolve(),
       commonjs(),
+      bundleSize(),
     ],
     // external: ['temporal-polyfill'],
   },
@@ -100,7 +116,8 @@ module.exports = [
         file: 'dist/bundle.min.js',
         format: 'iife',
         name: 'hebcal',
-        plugins: [terser()],
+
+        plugins: [terser(), bundleSize()],
         banner,
         sourcemap: true,
         inlineDynamicImports: true,
@@ -117,15 +134,19 @@ module.exports = [
       babel({
         babelHelpers: 'bundled',
         presets: [
-          ['@babel/preset-env', {
-            modules: false,
-            targets: TARGETS_BROWSER,
-            useBuiltIns: 'usage',
-            corejs: 3,
-          }],
+          [
+            '@babel/preset-env',
+            {
+              modules: false,
+              targets: TARGETS_BROWSER,
+              useBuiltIns: 'usage',
+              corejs: 3,
+            },
+          ],
         ],
         exclude: ['node_modules/core-js/**'],
       }),
+      bundleSize(),
     ],
     // external: ['temporal-polyfill'],
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,13 +1,13 @@
-const {nodeResolve} = require('@rollup/plugin-node-resolve');
-const commonjs = require('@rollup/plugin-commonjs');
-const babel = require('@rollup/plugin-babel');
-const bundleSize = require('rollup-plugin-bundle-size');
-const json = require('@rollup/plugin-json');
-const terser = require('@rollup/plugin-terser');
-const typescript = require('@rollup/plugin-typescript');
-const {dts} = require('rollup-plugin-dts');
-const pkg = require('./package.json');
-
+import {defineConfig} from 'rollup';
+import {nodeResolve} from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import bundleSize from 'rollup-plugin-bundle-size';
+import json from '@rollup/plugin-json';
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import {dts} from 'rollup-plugin-dts';
+import pkg from './package.json' with {type: 'json'};
 const banner = '/*! ' + pkg.name + ' v' + pkg.version + ' */';
 
 const TARGET_NODE_VER = '16.0.0';
@@ -18,7 +18,7 @@ const TARGETS_BROWSER = {
   safari: '15.6',
 };
 
-module.exports = [
+export default defineConfig([
   {
     input: 'src/index.ts',
     output: [
@@ -155,4 +155,4 @@ module.exports = [
     output: [{file: 'dist/module.d.ts', format: 'es'}],
     plugins: [dts()],
   },
-];
+]);

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from 'rollup';
+import {defineConfig, InputPluginOption, OutputOptions} from 'rollup';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from '@rollup/plugin-babel';
@@ -18,112 +18,78 @@ const TARGETS_BROWSER = {
   safari: '15.6',
 };
 
+const pluginsTargettingNode: InputPluginOption = [
+  typescript(),
+  json({compact: true, preferConst: true}),
+  babel({
+    babelHelpers: 'bundled',
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          modules: false,
+          targets: {
+            node: TARGET_NODE_VER,
+          },
+        },
+      ],
+    ],
+    exclude: ['node_modules/**'],
+  }),
+  nodeResolve(),
+  commonjs(),
+  bundleSize(),
+];
+const baseOutputOptions: OutputOptions = {
+  name: pkg.name,
+  banner,
+  sourcemap: true,
+  inlineDynamicImports: true,
+  globals: {
+    'temporal-polyfill': 'Temporal',
+  },
+};
 export default defineConfig([
   {
     input: 'src/index.ts',
     output: [
       {
+        ...baseOutputOptions,
         file: pkg.main,
         format: 'cjs',
-        name: pkg.name,
-        banner,
-        sourcemap: true,
-        inlineDynamicImports: true,
-        globals: {
-          'temporal-polyfill': 'Temporal',
-        },
       },
     ],
-    plugins: [
-      typescript(),
-      json({compact: true, preferConst: true}),
-      babel({
-        babelHelpers: 'bundled',
-        presets: [
-          [
-            '@babel/preset-env',
-            {
-              modules: false,
-              targets: {
-                node: TARGET_NODE_VER,
-              },
-            },
-          ],
-        ],
-        exclude: ['node_modules/**'],
-      }),
-      nodeResolve(),
-      commonjs(),
-      bundleSize(),
-    ],
+    plugins: pluginsTargettingNode,
     // external: ['temporal-polyfill'],
   },
   {
     input: 'src/index.ts',
     output: [
       {
+        ...baseOutputOptions,
         file: pkg.module,
         format: 'es',
-        name: pkg.name,
-        banner,
-        sourcemap: true,
-        inlineDynamicImports: true,
-        globals: {
-          'temporal-polyfill': 'Temporal',
-        },
       },
     ],
-    plugins: [
-      typescript(),
-      json({compact: true, preferConst: true}),
-      babel({
-        babelHelpers: 'bundled',
-        presets: [
-          [
-            '@babel/preset-env',
-            {
-              modules: false,
-              targets: {
-                node: TARGET_NODE_VER,
-              },
-            },
-          ],
-        ],
-        exclude: ['node_modules/**'],
-      }),
-      nodeResolve(),
-      commonjs(),
-      bundleSize(),
-    ],
+    plugins: pluginsTargettingNode,
     // external: ['temporal-polyfill'],
   },
   {
     input: 'src/index.ts',
     output: [
       {
+        ...baseOutputOptions,
         file: 'dist/bundle.js',
         format: 'iife',
         name: 'hebcal',
         indent: false,
-        banner,
-        sourcemap: true,
-        inlineDynamicImports: true,
-        globals: {
-          'temporal-polyfill': 'Temporal',
-        },
       },
       {
+        ...baseOutputOptions,
         file: 'dist/bundle.min.js',
         format: 'iife',
         name: 'hebcal',
-
-        plugins: [terser(), bundleSize()],
-        banner,
-        sourcemap: true,
-        inlineDynamicImports: true,
-        globals: {
-          'temporal-polyfill': 'Temporal',
-        },
+        plugins: [terser()],
       },
     ],
     plugins: [
@@ -131,6 +97,7 @@ export default defineConfig([
       json({compact: true, preferConst: true}),
       nodeResolve(),
       commonjs(),
+      // This uses different options than the common array above.
       babel({
         babelHelpers: 'bundled',
         presets: [

--- a/rollup.d.ts
+++ b/rollup.d.ts
@@ -1,0 +1,3 @@
+module 'rollup-plugin-bundle-size' {
+  export default function bundleSize(): import('rollup').Plugin;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -26,9 +26,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module":"ES6",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "Node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+
+    "module": "ESNext" /* Specify what module code is generated. */,
+    "moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -40,23 +40,23 @@
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true /* Enable importing .json files. */,
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -78,12 +78,12 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -105,7 +105,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "exclude": ["node_modules", "dist", "test", "docs",
     "version.cjs", "rollup.config.cjs", "jest.config.js", "po2json.cjs"]


### PR DESCRIPTION
I ended up not needing this (see https://github.com/SLaks/hebcal-es6/blob/modular/size-demo/rollup.config.ts), but I already wrote it, so here it is.