### PR TITLE
Switch to quick-lru v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@hebcal/core",
-  "version": "5.7.2",
+  "version": "5.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hebcal/core",
-      "version": "5.7.2",
+      "version": "5.7.4",
       "license": "GPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@hebcal/hdate": "^0.11.5",
         "@hebcal/noaa": "^0.8.14",
-        "quick-lru": "^6.1.2",
+        "quick-lru": "^4.0.0",
         "temporal-polyfill": "^0.2.5",
         "tslib": "^2.8.1"
       },
@@ -4463,16 +4463,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/caniuse-lite": {
@@ -9373,15 +9363,12 @@
       "license": "MIT"
     },
     "node_modules/quick-lru": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
-      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/randombytes": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@babel/runtime": "^7.26.0",
     "@hebcal/hdate": "^0.11.5",
     "@hebcal/noaa": "^0.8.14",
-    "quick-lru": "^6.1.2",
+    "quick-lru": "^4.0.0",
     "temporal-polyfill": "^0.2.5",
     "tslib": "^2.8.1"
   }


### PR DESCRIPTION
This fixes leyning's unit tests, by making this file CommonJS.

You should now be able to release this package (again...), upgrade the version in package.json in https://github.com/hebcal/hebcal-leyning/pull/473, then merge and release!