### PR TITLE
Improve translation for french

### DIFF
--- a/src/MevarchimChodeshEvent.ts
+++ b/src/MevarchimChodeshEvent.ts
@@ -13,10 +13,11 @@ export class MevarchimChodeshEvent extends Event {
    * @param date Hebrew date event occurs
    * @param monthName Hebrew month name (not translated)
    * @param [memo]
+   * @param locale Optional locale name
    */
-  constructor(date: HDate, monthName: string, memo: string) {
+  constructor(date: HDate, monthName: string, memo: string, locale?: string) {
     super(date, `${mevarchimChodeshStr} ${monthName}`, flags.SHABBAT_MEVARCHIM);
-    this.monthName = monthName;
+    this.monthName = Locale.gettext(monthName, locale);
     if (memo) {
       this.memo = memo;
     } else {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -670,7 +670,9 @@ function makeMoladAndMevarchimChodesh(hd: HDate, options: CalOptions): Event[] {
       const nextMonthName = HDate.getMonthName(monNext, hyear);
       const molad = new Molad(hyear, monNext);
       const memo = molad.render(options.locale || 'en', options);
-      evts.push(new MevarchimChodeshEvent(hd, nextMonthName, memo));
+      evts.push(
+        new MevarchimChodeshEvent(hd, nextMonthName, memo, options.locale)
+      );
     }
   }
   return evts;

--- a/src/molad.ts
+++ b/src/molad.ts
@@ -15,7 +15,7 @@ const heDayNames = [
   'שִׁישִּׁי',
   'שַׁבָּת',
 ];
-
+const frDayNames = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'];
 const night = 'בַּלַּ֥יְלָה';
 
 function getHebrewTimeOfDay(hour: number): string {
@@ -89,8 +89,9 @@ export class Molad {
     }
     const isHebrewLocale =
       locale === 'he' || locale === 'he-x-nonikud' || locale === 'h';
+    const isFrenchLocale = locale === 'fr';
     const monthName = Locale.gettext(this.getMonthName(), locale);
-    const dayNames = isHebrewLocale ? heDayNames : shortDayNames;
+    const dayNames = isHebrewLocale ? heDayNames : (isFrenchLocale ? frDayNames : shortDayNames);
     const dow = dayNames[this.getDow()];
     const minutes = this.getMinutes();
     const hour = this.getHour();
@@ -98,6 +99,8 @@ export class Molad {
     const moladStr = Locale.gettext('Molad', locale);
     const minutesStr = Locale.lookupTranslation('min', locale) ?? 'minutes';
     const chalakimStr = Locale.gettext('chalakim', locale);
+    const and = Locale.gettext('and', locale);
+    const after = Locale.gettext('after', locale);
     if (isHebrewLocale) {
       const ampm = getHebrewTimeOfDay(hour);
       const result =
@@ -112,7 +115,7 @@ export class Molad {
     }
     const fmtTime = reformatTimeStr(`${hour}:00`, 'pm', options);
     const month = monthName.replace(/'/g, '’');
-    return `${moladStr} ${month}: ${dow}, ${minutes} ${minutesStr} and ${chalakim} ${chalakimStr} after ${fmtTime}`;
+    return `${moladStr} ${month}: ${dow}, ${minutes} ${minutesStr} ${and} ${chalakim} ${chalakimStr} ${after} ${fmtTime}`;
   }
 }
 


### PR DESCRIPTION
Hello, This PR adds the ability to translate certain words from the Molad memo into French, makes the month translatable in the `MevarchimChedeshEvent` class, and allows the days of the week in the Molad memo to be translated.

Currently, some parts of the Molad memo, including specific words and the days of the week, are not translatable, which limits localization support. Additionally, the month names in `MevarchimChedeshEvent` should also be translatable to ensure consistency across languages.

This PR is related to another PR [in a hebcal/locales.](https://github.com/hebcal/hebcal-locales/pull/3)

