### PR TITLE
Add Temporal polyfill shim for conditional runtime support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hebcal/core",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hebcal/core",
-      "version": "6.3.3",
+      "version": "6.4.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@hebcal/hdate": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hebcal/core",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "author": "Michael J. Radwin (https://github.com/mjradwin)",
   "contributors": [
     "Eyal Schachter (https://github.com/Scimonster)",

--- a/src/molad.ts
+++ b/src/molad.ts
@@ -1,4 +1,4 @@
-import 'temporal-polyfill/global';
+import './temporal-shim';
 import {Event, flags} from './event';
 import {CalOptions} from './CalOptions';
 import {HDate, Locale, pad2} from '@hebcal/hdate';

--- a/src/moladDate.ts
+++ b/src/moladDate.ts
@@ -1,4 +1,4 @@
-import 'temporal-polyfill/global';
+import './temporal-shim';
 import {getTimezoneOffset} from '@hebcal/hdate';
 import {MoladBase} from './moladBase';
 

--- a/src/temporal-shim.ts
+++ b/src/temporal-shim.ts
@@ -1,0 +1,9 @@
+/// <reference types="temporal-polyfill/global" />
+import {Temporal as TemporalPolyfill} from 'temporal-polyfill';
+
+// Install the polyfill only when the runtime does not already provide a
+// native `Temporal` global (e.g. Node.js >= 26, future browsers).
+if (typeof (globalThis as {Temporal?: unknown}).Temporal === 'undefined') {
+  (globalThis as unknown as {Temporal: typeof TemporalPolyfill}).Temporal =
+    TemporalPolyfill;
+}

--- a/src/zmanim.ts
+++ b/src/zmanim.ts
@@ -1,4 +1,4 @@
-import 'temporal-polyfill/global';
+import './temporal-shim';
 import {GeoLocation, NOAACalculator} from '@hebcal/noaa';
 import {
   HDate,


### PR DESCRIPTION
## Summary
This PR introduces a conditional Temporal polyfill shim that only installs the polyfill when the runtime doesn't already provide native Temporal support. This allows the library to work seamlessly across different JavaScript runtimes while avoiding unnecessary polyfill installation in modern environments.

## Key Changes
- Created new `src/temporal-shim.ts` module that conditionally installs the Temporal polyfill only when `globalThis.Temporal` is undefined
- Updated `src/molad.ts`, `src/moladDate.ts`, and `src/zmanim.ts` to import the new shim instead of directly importing the polyfill
- Bumped version from 6.3.3 to 6.4.0

## Implementation Details
The shim checks if `Temporal` is already available on the global object before installing the polyfill. This approach:
- Supports Node.js >= 26 and future browsers that have native Temporal support
- Maintains backward compatibility with older runtimes by falling back to the polyfill
- Centralizes the polyfill installation logic in a single module, making it easier to manage and test
- Uses proper TypeScript type assertions to safely assign the polyfill to the global object

https://claude.ai/code/session_01XETZXDT6BwGM3K3rzbZZsj