### PR TITLE
Add isFastDay and isAveilut helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export {GeoLocation, NOAACalculator} from '@hebcal/noaa';
 export {Location} from './location';
 export {Zmanim} from './zmanim';
 export {isAssurBemlacha} from './isAssurBemlacha';
+export {isAveilut} from './isAveilut';
+export {isFastDay} from './isFastDay';
 export {TimedEvent, CandleLightingEvent, HavdalahEvent} from './TimedEvent';
 export {FastDayEvent, TimedChanukahEvent} from './candles';
 export {MoladBase, calculateMolad} from './moladBase';

--- a/src/isAveilut.ts
+++ b/src/isAveilut.ts
@@ -1,0 +1,43 @@
+import {HDate, months} from '@hebcal/hdate';
+
+const NISAN = months.NISAN;
+const SIVAN = months.SIVAN;
+const TAMUZ = months.TAMUZ;
+const AV = months.AV;
+const SAT = 6;
+
+function getHDate(date: HDate | Date | number): HDate {
+  return HDate.isHDate(date) ? (date as HDate) : new HDate(date);
+}
+
+function isSefiratHaOmer(hd: HDate): boolean {
+  const hyear = hd.getFullYear();
+  const beginOmer = new HDate(16, NISAN, hyear).abs();
+  const endOmer = new HDate(5, SIVAN, hyear).abs();
+  const abs = hd.abs();
+  return abs >= beginOmer && abs <= endOmer;
+}
+
+function isBeinHaMetzarim(hd: HDate): boolean {
+  const hyear = hd.getFullYear();
+  const begin = new HDate(17, TAMUZ, hyear).abs();
+  const tishaBav = new HDate(9, AV, hyear);
+  const end =
+    tishaBav.getDay() === SAT ? new HDate(10, AV, hyear).abs() : tishaBav.abs();
+  const abs = hd.abs();
+  return abs >= begin && abs <= end;
+}
+
+/**
+ * Utility method to determine if the given date is during a mourning period.
+ *
+ * This broad helper returns `true` during Sefirat HaOmer and Bein HaMetzarim.
+ * It does not attempt to model minhag-specific exceptions within those periods.
+ *
+ * @param date Hebrew Date, Gregorian date, or absolute R.D. day number
+ * @return `true` if the date is during a mourning period
+ */
+export function isAveilut(date: HDate | Date | number): boolean {
+  const hd = getHDate(date);
+  return isSefiratHaOmer(hd) || isBeinHaMetzarim(hd);
+}

--- a/src/isFastDay.ts
+++ b/src/isFastDay.ts
@@ -1,0 +1,22 @@
+import {HDate} from '@hebcal/hdate';
+import {flags} from './event';
+import {getHolidaysOnDate} from './holidays';
+
+const FAST_DAY = flags.MAJOR_FAST | flags.MINOR_FAST;
+const EREV = flags.EREV;
+
+/**
+ * Utility method to determine if the given date is a fast day.
+ *
+ * @param date Hebrew Date, Gregorian date, or absolute R.D. day number
+ * @param il use the Israeli schedule for holidays
+ * @return `true` if the date is a major or minor fast day
+ */
+export function isFastDay(date: HDate | Date | number, il?: boolean): boolean {
+  const events = getHolidaysOnDate(date, il) || [];
+  const fastDay = events.find(ev => {
+    const mask = ev.getFlags();
+    return mask & FAST_DAY && !(mask & EREV);
+  });
+  return Boolean(fastDay);
+}

--- a/test/isAveilut.spec.ts
+++ b/test/isAveilut.spec.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'vitest';
+import {HDate} from '@hebcal/hdate';
+import {isAveilut} from '../src/isAveilut';
+
+test('sefirat haomer', () => {
+  expect(isAveilut(new HDate(15, 'Nisan', 5785))).toBe(false);
+  expect(isAveilut(new HDate(16, 'Nisan', 5785))).toBe(true);
+  expect(isAveilut(new HDate(18, 'Iyyar', 5785))).toBe(true);
+  expect(isAveilut(new HDate(5, 'Sivan', 5785))).toBe(true);
+  expect(isAveilut(new HDate(6, 'Sivan', 5785))).toBe(false);
+});
+
+test('bein hametzarim', () => {
+  expect(isAveilut(new HDate(16, 'Tammuz', 5785))).toBe(false);
+  expect(isAveilut(new HDate(17, 'Tammuz', 5785))).toBe(true);
+  expect(isAveilut(new HDate(9, 'Av', 5785))).toBe(true);
+  expect(isAveilut(new HDate(10, 'Av', 5785))).toBe(false);
+});
+
+test('observed tisha bav extends through 10 av', () => {
+  expect(isAveilut(new HDate(9, 'Av', 5782))).toBe(true);
+  expect(isAveilut(new HDate(10, 'Av', 5782))).toBe(true);
+  expect(isAveilut(new HDate(11, 'Av', 5782))).toBe(false);
+});
+
+test('regular day', () => {
+  expect(isAveilut(new HDate(3, 'Cheshvan', 5785))).toBe(false);
+});

--- a/test/isFastDay.spec.ts
+++ b/test/isFastDay.spec.ts
@@ -1,0 +1,26 @@
+import {expect, test} from 'vitest';
+import {HDate} from '@hebcal/hdate';
+import {isFastDay} from '../src/isFastDay';
+
+test('major fast days', () => {
+  expect(isFastDay(new HDate(10, 'Tishrei', 5785))).toBe(true);
+  expect(isFastDay(new HDate(9, 'Av', 5785))).toBe(true);
+});
+
+test('minor fast days', () => {
+  expect(isFastDay(new HDate(4, 'Tishrei', 5785))).toBe(true);
+  expect(isFastDay(new HDate(10, 'Tevet', 5785))).toBe(true);
+  expect(isFastDay(new HDate(13, 'Adar', 5785))).toBe(true);
+  expect(isFastDay(new HDate(17, 'Tammuz', 5785))).toBe(true);
+});
+
+test('observed fast days', () => {
+  expect(isFastDay(new HDate(17, 'Tammuz', 5782))).toBe(false);
+  expect(isFastDay(new HDate(18, 'Tammuz', 5782))).toBe(true);
+  expect(isFastDay(new HDate(9, 'Av', 5782))).toBe(false);
+  expect(isFastDay(new HDate(10, 'Av', 5782))).toBe(true);
+});
+
+test('regular day', () => {
+  expect(isFastDay(new HDate(3, 'Cheshvan', 5785))).toBe(false);
+});


### PR DESCRIPTION
Adds two small date helpers requested in #617.

- isFastDay() checks existing holiday events for major or minor fast-day flags, while ignoring erev fast-day markers.
- isAveilut() covers broad mourning periods for Sefirat HaOmer and Bein HaMetzarim.

Included focused tests for major fasts, minor fasts, observed fast days, Omer boundaries, Bein HaMetzarim boundaries, and delayed Tish'a B'Av.

Checks:
- npm run compile
- npx vitest run test/isFastDay.spec.ts test/isAveilut.spec.ts

Fixes #617