### PR TITLE
Document holiday Shabbat title lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,39 @@ for (const ev of events) {
 }
 ```
 
+## Displaying the current Shabbat
+
+`ParshaEvent` is designed for regular weekly parsha readings. On Shabbatot
+with holiday readings, such as Shabbat Chol HaMoed, use holiday events or the
+`@hebcal/leyning` package instead.
+
+For a lightweight holiday title from `@hebcal/core`:
+
+```javascript
+import {HDate, getHolidaysOnDate, getSedra, ParshaEvent} from '@hebcal/core';
+
+const hdate = new HDate(new Date(2025, 9, 11));
+const sedra = getSedra(hdate.getFullYear(), true).lookup(hdate);
+const event = sedra.chag
+  ? getHolidaysOnDate(hdate, true)[0]
+  : new ParshaEvent(sedra);
+
+console.log(event.render('he'));
+```
+
+For full Torah reading metadata and Shabbat/holiday leyning titles:
+
+```javascript
+import {HDate} from '@hebcal/hdate';
+import {getLeyningOnDate} from '@hebcal/leyning';
+
+const hdate = new HDate(new Date(2025, 9, 11));
+const reading = getLeyningOnDate(hdate, true, false, 'he');
+
+console.log(reading.name.he);
+console.log(reading.summary);
+```
+
 ## Usage
 
 This package exports two categories of output:

--- a/src/ParshaEvent.ts
+++ b/src/ParshaEvent.ts
@@ -5,7 +5,12 @@ import {SedraResult} from './sedra';
 import './locale'; // Adds Hebrew and Ashkenazic translations
 
 /**
- * Represents one of 54 weekly Torah portions, always on a Saturday
+ * Represents one of 54 weekly Torah portions, always on a Saturday.
+ *
+ * `ParshaEvent` is for regular Parashat HaShavua readings. For Shabbatot
+ * with holiday readings such as Shabbat Chol ha-Moed, use
+ * `getHolidaysOnDate()` from `@hebcal/core`, or `getLeyningOnDate()` from
+ * `@hebcal/leyning` when the display title and exact Torah readings are needed.
  */
 export class ParshaEvent extends Event {
   readonly p: SedraResult;


### PR DESCRIPTION
Adds guidance for displaying the current Shabbat title when the weekly sedra is replaced by a holiday reading.

- Clarifies that `ParshaEvent` is intended for regular weekly parsha readings.
- Adds a README example using `getHolidaysOnDate()` for a lightweight title.
- Points users to `@hebcal/leyning` and `getLeyningOnDate()` when they need Shabbat/holiday leyning titles and Torah reading metadata.

This addresses the confusion described in #499 without changing `ParshaEvent` behavior.

Checks:
- npm run compile