### PR TITLE
Classify Chanukah candles as minor holidays

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -68,7 +68,7 @@ export const flags = {
 
 const flagToCategory = [
   [flags.MAJOR_FAST, 'holiday', 'major', 'fast'],
-  [flags.CHANUKAH_CANDLES, 'holiday', 'major'],
+  [flags.CHANUKAH_CANDLES, 'holiday', 'minor'],
   [flags.HEBREW_DATE, 'hebdate'],
   [flags.MINOR_FAST, 'holiday', 'fast'],
   [flags.MINOR_HOLIDAY, 'holiday', 'minor'],

--- a/test/holidays.spec.js
+++ b/test/holidays.spec.js
@@ -440,4 +440,12 @@ test('getCategories', () => {
   const ev3 = new HolidayEvent(new HDate(9, months.TISHREI, 5763),
       'Erev Yom Kippur', flags.EREV | flags.LIGHT_CANDLES);
   expect(ev3.getCategories()).toEqual(['holiday', 'major']);
+
+  const events = HebrewCalendar.calendar({
+    start: new HDate(25, months.KISLEV, 5784),
+    end: new HDate(26, months.KISLEV, 5784),
+  });
+  const ev4 = events.find((ev) => ev.basename() === 'Chanukah');
+  expect(ev4).toBeDefined();
+  expect(ev4.getCategories()).toEqual(['holiday', 'minor']);
 });


### PR DESCRIPTION
Fixes #386.

This updates the category mapping for `flags.CHANUKAH_CANDLES` so Chanukah candle events return `["holiday", "minor"]` from `getCategories()`.

The regression test uses the same `HebrewCalendar.calendar()` date range from the reopened issue comment.

Checks:
- `npm run compile`
- `npx vitest run test/holidays.spec.js --testNamePattern getCategories`
- `TZ=UTC npx vitest run test/isAssurBemlacha.spec.ts`
- `TZ=America/New_York npx vitest run test/isAssurBemlacha.spec.ts`

Note: running the full suite in a local `Asia/Jerusalem` process timezone currently fails the existing `test/isAssurBemlacha.spec.ts` `sat before havdalah` assertion. That appears unrelated to this category change; the same test file passes under `TZ=UTC` and `TZ=America/New_York`.