### PR TITLE
Fix tmp CVE-2026-44705 via override; clean up size-demo lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
       'test/',
       'docs/',
       'dist/',
+      'size-demo/',
       'src/*.json.ts',
       'src/*.po.ts',
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4451,16 +4451,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5533,16 +5523,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/trim-newlines": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "prepare": "npm run compile"
   },
   "license": "GPL-2.0",
+  "overrides": {
+    "tmp": "^0.2.6"
+  },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",


### PR DESCRIPTION
Force the dev-only transitive `tmp` dependency (pulled in by
gts -> inquirer@7 -> external-editor) to the patched ^0.2.6, resolving
CVE-2026-44705 (path traversal). tmp is build/dev-time only and not
shipped in dist/, so runtime consumers were never affected.

Also ignore size-demo/ in eslint config (consistent with build/, test/,
docs/, dist/), since those files are excluded from the root tsconfig and
were producing spurious parserOptions.project parse errors during lint.