### PR TITLE
Add Ashkenazi transliteration for Rosh Hashana LaBehemot

### DIFF
--- a/po/ashkenazi.po
+++ b/po/ashkenazi.po
@@ -61,6 +61,9 @@ msgstr "Pesach Shabbos Chol ha-Moed"
 msgid "Purim Katan"
 msgstr "Purim Koton"
 
+msgid "Rosh Hashana LaBehemot"
+msgstr "Rosh Hashana LaBeheimos"
+
 msgid "Shabbat Chazon"
 msgstr "Shabbos Chazon"
 


### PR DESCRIPTION
Adds the missing `ashkenazi` locale entry for `Rosh Hashana LaBehemot` to `po/ashkenazi.po`: