### PR TITLE
Add weekday sedra lookup

### DIFF
--- a/src/sedra.ts
+++ b/src/sedra.ts
@@ -368,6 +368,76 @@ export class Sedra {
       il: this.il,
     };
   }
+
+  /**
+   * Returns details about the parsha read on Monday or Thursday for `hd`, or
+   * `undefined` if `hd` is not a Monday or Thursday.
+   *
+   * Weekday Torah readings generally begin the upcoming Shabbat parsha. When
+   * the upcoming Shabbat is a holiday, this method returns the next regular
+   * parsha instead.
+   *
+   * For the Tishrei weekdays before Sukkot or Simchat Torah, the weekday
+   * reading is *Vezot Haberakhah* even though it is not read on Shabbat.
+   * @param hd Hebrew date or R.D. days
+   */
+  lookupWeekday(hd: HDate | number): SedraResult | undefined {
+    const abs =
+      typeof hd === 'number' ? hd : HDate.isHDate(hd) ? hd.abs() : NaN;
+
+    if (isNaN(abs)) {
+      throw new TypeError(`Bad date argument: ${hd}`);
+    } else if (abs < this.rh) {
+      throw new RangeError(
+        `Date ${hd} before start of Hebrew year ${this.year}`
+      );
+    }
+
+    const hdate = new HDate(abs);
+    const day = hdate.getDay();
+    if (day !== 1 && day !== 4) {
+      return undefined;
+    }
+
+    const saturday = new HDate(HDate.dayOnOrBefore(6, abs + 6));
+    const parsha = this.lookup(saturday);
+    if (!parsha.chag) {
+      return parsha;
+    }
+    return this.findWeekdayParsha(saturday);
+  }
+
+  private findWeekdayParsha(saturday: HDate): SedraResult {
+    const hyear = saturday.getFullYear();
+    const il = this.il;
+
+    if (saturday.getMonth() === months.TISHREI) {
+      const dd = saturday.getDate();
+      const simchatTorah = il ? 22 : 23;
+      if (dd > 2 && dd <= simchatTorah) {
+        return {
+          parsha: ['Vezot Haberakhah'],
+          chag: false,
+          num: 54,
+          hdate: saturday,
+          il,
+        };
+      }
+    }
+
+    const sedra = hyear === this.year ? this : getSedra(hyear, il);
+    const endOfYear = new HDate(1, months.TISHREI, hyear + 1).abs() - 1;
+    const endAbs = endOfYear + 30;
+    for (let sat2 = saturday.abs() + 7; sat2 <= endAbs; sat2 += 7) {
+      const sedra2 = sat2 > endOfYear ? getSedra(hyear + 1, il) : sedra;
+      const parsha2 = sedra2.lookup(sat2);
+      if (!parsha2.chag) {
+        return parsha2;
+      }
+    }
+    /* NOTREACHED */
+    throw new Error(`can't find weekday parsha for ${saturday}/${il}`);
+  }
 }
 
 /**

--- a/test/sedra.spec.ts
+++ b/test/sedra.spec.ts
@@ -212,6 +212,58 @@ test('weekday1', () => {
   });
 });
 
+test('lookupWeekday returns weekday parsha when Shabbat is a holiday', () => {
+  const sedra = new Sedra(5785, false);
+  const tishrei5 = new HDate(5, months.TISHREI, 5785);
+  const result = sedra.lookupWeekday(tishrei5);
+  expect(result).toEqual({
+    parsha: ['Vezot Haberakhah'],
+    chag: false,
+    num: 54,
+    il: false,
+    hdate: new HDate(739171),
+  });
+});
+
+test('lookupWeekday handles Tishrei and Pesach holiday weeks', () => {
+  const sedra5786 = new Sedra(5786, false);
+  const erevSukkot = new HDate(14, months.TISHREI, 5786);
+  expect(sedra5786.lookupWeekday(erevSukkot)?.parsha).toEqual([
+    'Vezot Haberakhah',
+  ]);
+
+  const sedra5700 = new Sedra(5700, false);
+  const erevPesach = new HDate(14, months.NISAN, 5700);
+  expect(sedra5700.lookupWeekday(erevPesach)?.parsha).toEqual(['Kedoshim']);
+});
+
+test('lookupWeekday returns undefined for non-weekday reading days', () => {
+  const sedra = new Sedra(5785, false);
+  const tishrei7 = new HDate(7, months.TISHREI, 5785);
+  expect(sedra.lookupWeekday(tishrei7)).toBeUndefined();
+});
+
+test('lookupWeekday resolves Monday and Thursday readings for full years', () => {
+  for (let year = 5700; year < 5900; year++) {
+    for (const il of [false, true]) {
+      const sedra = new Sedra(year, il);
+      const startAbs = HDate.hebrew2abs(year, months.TISHREI, 1);
+      const endAbs = HDate.hebrew2abs(year + 1, months.TISHREI, 1) - 1;
+      for (let abs = startAbs; abs <= endAbs; abs++) {
+        const hd = new HDate(abs);
+        const day = hd.getDay();
+        if (day !== 1 && day !== 4) {
+          continue;
+        }
+        const result = sedra.lookupWeekday(hd);
+        expect(result?.chag).toBe(false);
+        expect(result?.num).not.toBe(0);
+        expect(result?.parsha.length).toBeGreaterThan(0);
+      }
+    }
+  }
+});
+
 test('Shabbos Chol Hamoed Pesach', () => {
   const years = [5786, 5783, 5780, 5777];
   for (const year of years) {
@@ -248,4 +300,3 @@ test('Pesach Diaspora', () => {
     }
   }
 });
-


### PR DESCRIPTION
Fixes #453.

## Summary
- add `Sedra.lookupWeekday(hd)` for Monday/Thursday parsha lookup
- return the upcoming regular parsha when Shabbat is a holiday
- handle Tishrei weekday readings for `Vezot Haberakhah` and add full-year coverage tests

## Validation
- `npx vitest run test/sedra.spec.ts`
- `npm run compile` after clearing ignored `dist/` output
- `TZ=UTC npx vitest run`
- `npm run lint`

`TZ=UTC npm test -- --run` currently stops during the pretest Rollup build because the IIFE bundle hits top-level await in `@hebcal/noaa/dist/index.js`.