### PR TITLE
fix(he): natural Hebrew word order and spelling for Shabbat Chol ha-Moed

### DIFF
--- a/po/he-x-NoNikud.po
+++ b/po/he-x-NoNikud.po
@@ -22,10 +22,10 @@ msgid "Yom Kippur Katan"
 msgstr "יום כיפור קטן"
 
 msgid "Pesach Shabbat Chol ha-Moed"
-msgstr "פסח שבת חול המועד"
+msgstr "שבת חול המועד פסח"
 
 msgid "Sukkot Shabbat Chol ha-Moed"
-msgstr "סוכות שבת חול המועד"
+msgstr "שבת חול המועד סוכות"
 
 msgid "Erev Sukkot"
 msgstr "ערב סוכות"

--- a/po/he.po
+++ b/po/he.po
@@ -299,7 +299,7 @@ msgid "Pesach VIII"
 msgstr "פֶּסַח ח׳"
 
 msgid "Pesach Shabbat Chol ha-Moed"
-msgstr "פֶּסַח שַׁבָּת חֹל הַמּוֹעֵד"
+msgstr "שַׁבַּת חוֹל הַמּוֹעֵד פֶּסַח"
 
 msgid "Purim"
 msgstr "פּוּרִים"
@@ -392,7 +392,7 @@ msgid "Sukkot VII (Hoshana Raba)"
 msgstr "סֻכּוֹת ז׳ (הוֹשַׁעְנָא רַבָּה)"
 
 msgid "Sukkot Shabbat Chol ha-Moed"
-msgstr "סֻכּוֹת שַׁבָּת חֹל הַמּוֹעֵד"
+msgstr "שַׁבַּת חוֹל הַמּוֹעֵד סֻכּוֹת"
 
 msgid "Ta'anit Bechorot"
 msgstr "תַּעֲנִית בְּכוֹרוֹת"


### PR DESCRIPTION
Follow-up to hebcal/hebcal-leyning#738, where @mjradwin approved this change.
The Hebrew strings live here in @hebcal/core rather than in hebcal-leyning.

### Problem
The Hebrew for the two Shabbat Chol ha-Moed keys placed the festival name first,
mirroring English word order. In Hebrew the Shabbat is the head noun, so the
festival belongs last.

### Change
| msgid | before | after |
|---|---|---|
| `Pesach Shabbat Chol ha-Moed` | `פֶּסַח שַׁבָּת חֹל הַמּוֹעֵד` | `שַׁבַּת חוֹל הַמּוֹעֵד פֶּסַח` |
| `Sukkot Shabbat Chol ha-Moed` | `סֻכּוֹת שַׁבָּת חֹל הַמּוֹעֵד` | `שַׁבַּת חוֹל הַמּוֹעֵד סֻכּוֹת` |

Three corrections, all within the same two strings:

1. **Word order** — the festival moves last; in Hebrew the Shabbat is the head noun.
2. **Construct form** — `שַׁבָּת` (kamatz) → `שַׁבַּת` (patach), matching every other
   `Shabbat *` entry in this file: `שַׁבַּת חֲזוֹן`, `שַׁבַּת הַגָּדוֹל`, `שַׁבַּת נַחֲמוּ`,
   `שַׁבַּת פָּרָה`, `שַׁבַּת שְׁקָלִים`, `שַׁבַּת שׁוּבָה`, `שַׁבַּת זָכוֹר`, `שַׁבַּת שִׁירָה`.
   These two keys were the only festival-first exceptions.
3. **Spelling** — `חֹל` → `חוֹל`. The vav is a root letter (ח־ו־ל) and is retained
   in pointed spelling. These two strings are the only occurrences of
   `חֹל הַמּוֹעֵד` in this repo, so nothing else is affected.

Note: `hebcal-leyning`'s `po/he.po` spells the `Pesach/Sukkot Chol ha-Moed Day N`
entries with `חֹל`. Happy to send a follow-up PR there for consistency if you'd like.

The same reordering is applied in `po/he-x-NoNikud.po` (already spelled `חול`).

### Verification
`npm test` — 316 passing. The one failure (`test/isAssurBemlacha.spec.ts`,
timezone-dependent) reproduces on unmodified `main`, so it is unrelated to this
change. Only the `.po` sources change; `src/*.po.ts` are generated and gitignored.
